### PR TITLE
Update Maven Central repository

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -39,7 +39,7 @@
 	<repositories>
 		<repository>
 			<id>central</id>
-			<url>http://central.maven.org/maven2/</url>
+			<url>https://repo.maven.apache.org/maven2</url>
 		</repository>
 	</repositories>
 </project>


### PR DESCRIPTION
Fix for issue https://github.com/getalp/UFSAC/issues/4
Simply updates Central Maven Repository to https://repo.maven.apache.org/maven2, as proposed in https://stackoverflow.com/questions/59763531/maven-dependencies-are-failing-with-501-error/59763928#59763928